### PR TITLE
fixed negative var rounding bug

### DIFF
--- a/estimators/bandits/gaussian.py
+++ b/estimators/bandits/gaussian.py
@@ -29,7 +29,7 @@ class Interval(base.Interval):
         z_gaussian_cdf = stats.norm.ppf(1 - alpha / 2)
         variance = (self.weighted_reward_sq - self.weighted_reward**2 / self.examples_count) / \
                    (self.examples_count - 1)
-        gauss_delta = z_gaussian_cdf * math.sqrt(variance / self.examples_count)
+        gauss_delta = z_gaussian_cdf * math.sqrt(max(0, variance) / self.examples_count)
         ips = self.weighted_reward / self.examples_count
         return [ips - gauss_delta, ips + gauss_delta]
 

--- a/estimators/test/test_bandits.py
+++ b/estimators/test/test_bandits.py
@@ -22,6 +22,11 @@ def assert_interval_covers(estimator, simulator, expected):
     assert scenario.result[0] <= expected
     assert scenario.result[1] >= expected
 
+def assert_interval_within(estimator, simulator, expected):
+    scenario = Scenario(simulator, estimator())
+    scenario.get_interval()
+    assert scenario.result[0] >= expected[0]
+    assert scenario.result[1] <= expected[1]
 
 def test_estimate_1_from_1s():
     ''' To test correctness of estimators: Compare the expected value with value returned by Estimator.get()'''
@@ -128,13 +133,6 @@ def test_higher_alpha_tighter_intervals():
     assert_higher_alpha_tighter_intervals(cs.Interval, simulator)     
 
 
-def assert_interval_within(estimator, simulator, expected):
-    scenario = Scenario(simulator, estimator())
-    scenario.get_interval()
-    assert scenario.result[0] >= expected[0]
-    assert scenario.result[1] <= expected[1]
-
-
 def assert_estimation_is_none(estimator):
     assert estimator().get() is None
 
@@ -177,15 +175,19 @@ def test_simple_convergence():
    
     # TODO: test + fix for cressieread with negative rewards
 
-def test_interval_sumsq_eq_sqsum():
+def test_zero_variance_reward():
+    r = 0.751
     def simulator():
-        for i in range(10):
+        for i in range(100):
             yield {'p_log': 0.5,
-                    'r': 0.3,
-                    'p_pred': 0.8}
-    expected = (0.4, 0.6)
+                    'r': r,
+                    'p_pred': 0.5}
+    expected = (0.7, 0.8)
     #got a math domain error before the fix (variance was negative due to rounding errors)
     assert_interval_within(gaussian.Interval, lambda: simulator(), expected)
+    assert_interval_within(lambda: clopper_pearson.Interval(0, r), lambda: simulator(), expected)
+    assert_interval_within(lambda: cressieread.Interval(rmin=0, rmax=r), lambda: simulator(), expected)
+    assert_interval_within(lambda: cs.Interval(rmin=0, rmax=r), lambda: simulator(), expected)
 
 def test_convergence_with_no_overflow():
     def simulator():

--- a/estimators/test/test_bandits.py
+++ b/estimators/test/test_bandits.py
@@ -177,6 +177,16 @@ def test_simple_convergence():
    
     # TODO: test + fix for cressieread with negative rewards
 
+def test_interval_sumsq_eq_sqsum():
+    def simulator():
+        for i in range(10):
+            yield {'p_log': 0.5,
+                    'r': 0.3,
+                    'p_pred': 0.8}
+    expected = (0.4, 0.6)
+    #got a math domain error before the fix (variance was negative due to rounding errors)
+    assert_interval_within(gaussian.Interval, lambda: simulator(), expected)
+
 def test_convergence_with_no_overflow():
     def simulator():
         for i in range(1000000):


### PR DESCRIPTION
evaluations on 'fake' data were failing due to a rounding error when the sum of squares was equal to the square of sums 