### PR TITLE
handle empty candidates

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, '3.10']
+        python-version: [3.7, 3.8, 3.9, '3.10']
 
     steps:
     - uses: actions/checkout@v2

--- a/estimators/bandits/cressieread.py
+++ b/estimators/bandits/cressieread.py
@@ -211,7 +211,10 @@ class IntervalImpl:
                             gstar = x - sqrt(2 * y * z)
                             candidates.append(gstar)
 
-            best = min(candidates)
+            if candidates and len(candidates) > 0:
+                best = min(candidates)
+            else:
+                best = 0
             vbound = min(self.rmax, max(self.rmin, sign * best))
             bounds.append(vbound)
 

--- a/estimators/bandits/cressieread.py
+++ b/estimators/bandits/cressieread.py
@@ -214,7 +214,7 @@ class IntervalImpl:
             if candidates and len(candidates) > 0:
                 best = min(candidates)
             else:
-                best = 0
+                best = self.rmin
             vbound = min(self.rmax, max(self.rmin, sign * best))
             bounds.append(vbound)
 


### PR DESCRIPTION
In evaluations we hit an edge case case where the candidates list is empty when getting the Cressie Read CI.

By default wmin is set to 0 and wmax to inf, so I think we are hitting an edge case where the two conditions are not satisfied

if isclose(y * z, 0, abs_tol=atol * atol):
                        gstar = x - sqrt(2) * atol
                        candidates.append(gstar)
elif z <= 0 and y * z >= 0:
                        gstar = x - sqrt(2 * y * z)
                        candidates.append(gstar)

Based on  the c++ code, rmin is the best way to deal with empty candidates.

https://github.com/VowpalWabbit/vowpal_wabbit/blob/748bc56735a000927f7795e5f316ca3861302a1d/vowpalwabbit/core/src/distributionally_robust.cc#L236