### PR TITLE
refactor: change to tuple instead of list for intervals

### DIFF
--- a/src/estimators/bandits/base.py
+++ b/src/estimators/bandits/base.py
@@ -1,7 +1,7 @@
 """ Interface for implementation of contextual bandit estimators """
 
 from abc import ABC, abstractmethod
-from typing import List, Optional
+from typing import Tuple, Optional
 
 
 class Estimator(ABC):
@@ -50,7 +50,7 @@ class Interval(ABC):
         ...
 
     @abstractmethod
-    def get(self, alpha: float) -> List[Optional[float]]:
+    def get(self, alpha: float) -> Tuple[Optional[float], Optional[float]]:
         """Calculates the CI
         Args:
                 alpha: alpha value

--- a/src/estimators/bandits/clopper_pearson.py
+++ b/src/estimators/bandits/clopper_pearson.py
@@ -1,5 +1,5 @@
 from estimators.bandits import base
-from typing import List, Optional
+from typing import List, Optional, Tuple
 from estimators.math import clopper_pearson
 
 
@@ -41,13 +41,13 @@ class Interval(base.Interval):
         self.weighted_reward += r * w
         self.max_weight = max(self.max_weight, w)
 
-    def get(self, alpha: float = 0.05) -> List[Optional[float]]:
+    def get(self, alpha: float = 0.05) -> Tuple[Optional[float], Optional[float]]:
         if self.max_weight > 0.0:
             successes = self.weighted_reward / self.max_weight
             n = self.examples_count / self.max_weight
             cp = clopper_pearson(successes, n, alpha)
-            return [self._scale_back(cp[0]), self._scale_back(cp[1])]
-        return [None, None]
+            return (self._scale_back(cp[0]), self._scale_back(cp[1]))
+        return (None, None)
 
     def __add__(self, other: "Interval") -> "Interval":
         result = Interval()

--- a/src/estimators/bandits/cressieread.py
+++ b/src/estimators/bandits/cressieread.py
@@ -2,7 +2,7 @@
 
 from math import inf
 from estimators.bandits import base
-from typing import List, Optional
+from typing import List, Optional, Tuple
 from estimators.math import IncrementalFsum
 
 
@@ -156,13 +156,15 @@ class IntervalImpl:
                     f"Error: Value of r={r} is outside rmin={self.rmin}, rmax={self.rmax} bounds"
                 )
 
-    def get(self, alpha: float = 0.05, atol: float = 1e-9) -> List[Optional[float]]:
+    def get(
+        self, alpha: float = 0.05, atol: float = 1e-9
+    ) -> Tuple[Optional[float], Optional[float]]:
         from math import isclose, sqrt
         from scipy.stats import f  # type: ignore
 
         n = float(self.n)
         if n == 0:
-            return [None, None]
+            return (None, None)
 
         sumw = float(self.sumw)
         sumwsq = float(self.sumwsq)
@@ -228,7 +230,7 @@ class IntervalImpl:
             vbound = min(self.rmax, max(self.rmin, sign * best))
             bounds.append(vbound)
 
-        return bounds
+        return (bounds[0], bounds[1])
 
     def __add__(self, other: "IntervalImpl") -> "IntervalImpl":
         assert not (
@@ -302,7 +304,9 @@ class Interval(base.Interval):
     ) -> None:
         self._impl.add(p_pred / p_log, r, p_drop, n_drop)
 
-    def get(self, alpha: float = 0.05, atol: float = 1e-9) -> List[Optional[float]]:
+    def get(
+        self, alpha: float = 0.05, atol: float = 1e-9
+    ) -> Tuple[Optional[float], Optional[float]]:
         return self._impl.get(alpha, atol)
 
     def __add__(self, other: "Interval") -> "Interval":

--- a/src/estimators/bandits/cs.py
+++ b/src/estimators/bandits/cs.py
@@ -1,6 +1,6 @@
 import typing
 from estimators.bandits import base
-from typing import List, Optional
+from typing import List, Optional, Tuple
 from estimators.math import IncrementalFsum
 
 
@@ -146,9 +146,9 @@ class IntervalImpl:
 
         self.t += 1
 
-    def get(self, alpha: float) -> List[Optional[float]]:
+    def get(self, alpha: float) -> Tuple[Optional[float], Optional[float]]:
         if self.t == 0 or self.rmin == self.rmax:
-            return [None, None]
+            return (None, None)
 
         sumvlow = (
             (
@@ -188,10 +188,10 @@ class IntervalImpl:
             t=self.t, sumXt=sumXhigh, v=sumvhigh, rho=self.rho, alpha=alpha / 2
         )
 
-        return [
+        return (
             self.rmin + l * (self.rmax - self.rmin),
             self.rmin + u * (self.rmax - self.rmin),
-        ]
+        )
 
 
 class Interval(base.Interval):
@@ -212,7 +212,9 @@ class Interval(base.Interval):
     ) -> None:
         self._impl.add(p_pred / p_log, r, p_drop, n_drop)
 
-    def get(self, alpha: float = 0.05, atol: float = 1e-9) -> List[Optional[float]]:
+    def get(
+        self, alpha: float = 0.05, atol: float = 1e-9
+    ) -> Tuple[Optional[float], Optional[float]]:
         return self._impl.get(alpha)
 
     def __add__(self, other: "Interval") -> "Interval":

--- a/src/estimators/bandits/gaussian.py
+++ b/src/estimators/bandits/gaussian.py
@@ -1,7 +1,7 @@
 import math
 from estimators.bandits import base
 from scipy import stats  # type: ignore
-from typing import List, Optional, cast
+from typing import List, Optional, Tuple, cast
 
 
 class Interval(base.Interval):
@@ -30,9 +30,9 @@ class Interval(base.Interval):
         self.weighted_reward += r * w
         self.weighted_reward_sq += (r * w) ** 2
 
-    def get(self, alpha: float = 0.05) -> List[Optional[float]]:
+    def get(self, alpha: float = 0.05) -> Tuple[Optional[float], Optional[float]]:
         if self.examples_count <= 1:
-            return [None, None]
+            return (None, None)
 
         z_gaussian_cdf = stats.norm.ppf(1 - alpha / 2)
         variance = (
@@ -40,7 +40,7 @@ class Interval(base.Interval):
         ) / (self.examples_count - 1)
         gauss_delta = z_gaussian_cdf * math.sqrt(max(0, variance) / self.examples_count)
         ips = self.weighted_reward / self.examples_count
-        return [ips - gauss_delta, ips + gauss_delta]
+        return (ips - gauss_delta, ips + gauss_delta)
 
     def __add__(self, other: "Interval") -> "Interval":
         result = Interval()

--- a/src/estimators/ccb/base.py
+++ b/src/estimators/ccb/base.py
@@ -1,7 +1,7 @@
 """ Interface for implementation of conditional contextual bandits estimators """
 
 from abc import ABC, abstractmethod
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 
 class Estimator(ABC):
@@ -52,7 +52,7 @@ class Interval(ABC):
         ...
 
     @abstractmethod
-    def get(self, alpha: float) -> List[List[Optional[float]]]:
+    def get(self, alpha: float) -> List[Tuple[Optional[float], Optional[float]]]:
         """Calculates the CI
         Args:
                 alpha: alpha value

--- a/src/estimators/ccb/first_slot.py
+++ b/src/estimators/ccb/first_slot.py
@@ -1,6 +1,6 @@
 from estimators.ccb import base
 from estimators.bandits import base as bandits_base
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 
 class Estimator(base.Estimator):
@@ -74,7 +74,7 @@ class Interval(base.Interval):
         self.slots_count = max(self.slots_count, len(p_logs))
         self.impl.add_example(p_logs[0], rs[0], p_preds[0], p_drop, n_drop)
 
-    def get(self, alpha: float = 0.05) -> List[List[Optional[float]]]:
+    def get(self, alpha: float = 0.05) -> List[Tuple[Optional[float], Optional[float]]]:
         if self.slots_count > 0:
-            return [self.impl.get(alpha)] + [[0, 0]] * (self.slots_count - 1)
+            return [self.impl.get(alpha)] + [(0, 0)] * (self.slots_count - 1)
         return []

--- a/src/estimators/ccb/multislot.py
+++ b/src/estimators/ccb/multislot.py
@@ -158,17 +158,17 @@ class Interval:
             impression = self.get_impression(alpha)
             r_given_impression = self.get_r_given_impression(alpha, atol)
             for slot_id in self._impl.keys():
-                impression_left, impression_right = impression[slot_id]
-                r_given_impression_left, r_given_impression_right = r_given_impression[
-                    slot_id
-                ]
-                result[slot_id] = (
-                    impression_left * r_given_impression_left
-                    if r_given_impression_left is not None
-                    else None,
-                    impression_right * r_given_impression_right
-                    if r_given_impression_right is not None
-                    else None,
+                # We can safely cast here because we know the tuples used in the expression are of length 2
+                result[slot_id] = typing.cast(
+                    Tuple[Optional[float], Optional[float]],
+                    tuple(
+                        [
+                            a * b if b is not None else None
+                            for a, b in zip(
+                                impression[slot_id], r_given_impression[slot_id]
+                            )
+                        ]
+                    ),
                 )
         return result
 

--- a/src/estimators/ccb/multislot.py
+++ b/src/estimators/ccb/multislot.py
@@ -160,17 +160,15 @@ class Interval:
             impression = self.get_impression(alpha)
             r_given_impression = self.get_r_given_impression(alpha, atol)
             for slot_id in self._impl.keys():
-                # We can safely cast here because we know the tuples used in the expression are of length 2
-                result[slot_id] = typing.cast(
-                    Tuple[Optional[float], Optional[float]],
-                    tuple(
-                        [
-                            a * b if b is not None else None
-                            for a, b in zip(
-                                impression[slot_id], r_given_impression[slot_id]
-                            )
-                        ]
-                    ),
+                _impression = impression[slot_id]
+                _r_given_impression = r_given_impression[slot_id]
+                result[slot_id] = (
+                    _impression[0] * _r_given_impression[0]
+                    if _r_given_impression[0] is not None
+                    else None,
+                    _impression[1] * _r_given_impression[1]
+                    if _r_given_impression[1] is not None
+                    else None,
                 )
         return result
 

--- a/src/estimators/ccb/multislot.py
+++ b/src/estimators/ccb/multislot.py
@@ -1,5 +1,5 @@
 from math import inf
-from typing import Callable, List, Dict, Optional
+from typing import Callable, List, Dict, Optional, Tuple
 import typing
 from estimators.bandits.cressieread import EstimatorImpl, IntervalImpl
 from estimators.math import IncrementalFsum, clopper_pearson
@@ -131,8 +131,7 @@ class Interval:
                 )
             self._impl[slot_ids[i]].add(w, rs[i], p_drop, n_drop)
 
-    # TODO: update return type to Dict[str, Tuple[float]]
-    def get_impression(self, alpha: float = 0.05) -> Dict[str, List[float]]:
+    def get_impression(self, alpha: float = 0.05) -> Dict[str, Tuple[float, float]]:
         result = {}
         # Does self.n > 0 guarantee that each slot has at least one example?
         if float(self.n) > 0:
@@ -144,7 +143,7 @@ class Interval:
 
     def get_r_given_impression(
         self, alpha: float = 0.05, atol: float = 1e-9
-    ) -> Dict[str, List[Optional[float]]]:
+    ) -> Dict[str, Tuple[Optional[float], Optional[float]]]:
         result = {}
         if float(self.n) > 0:
             for slot_id, estimator in self._impl.items():
@@ -153,21 +152,29 @@ class Interval:
 
     def get_r(
         self, alpha: float = 0.05, atol: float = 1e-9
-    ) -> Dict[str, List[Optional[float]]]:
+    ) -> Dict[str, Tuple[Optional[float], Optional[float]]]:
         result = {}
         if float(self.n) > 0:
             impression = self.get_impression(alpha)
             r_given_impression = self.get_r_given_impression(alpha, atol)
             for slot_id in self._impl.keys():
-                result[slot_id] = [
-                    a * b if b is not None else None
-                    for a, b in zip(impression[slot_id], r_given_impression[slot_id])
+                impression_left, impression_right = impression[slot_id]
+                r_given_impression_left, r_given_impression_right = r_given_impression[
+                    slot_id
                 ]
+                result[slot_id] = (
+                    impression_left * r_given_impression_left
+                    if r_given_impression_left is not None
+                    else None,
+                    impression_right * r_given_impression_right
+                    if r_given_impression_right is not None
+                    else None,
+                )
         return result
 
     def get_r_overall(
         self, alpha: float = 0.05, atol: float = 1e-9
-    ) -> List[Optional[float]]:
+    ) -> Tuple[Optional[float], Optional[float]]:
         return sum(
             self._impl.values(),
             IntervalImpl(0, inf, self.rmin, self.rmax, self.empirical_r_bounds),

--- a/src/estimators/ccb/pdis_cressieread.py
+++ b/src/estimators/ccb/pdis_cressieread.py
@@ -1,7 +1,7 @@
 import typing
 from estimators.ccb import base
 from math import inf
-from typing import List, Optional
+from typing import List, Optional, Tuple
 from estimators.bandits.cressieread import EstimatorImpl, IntervalImpl
 from copy import deepcopy
 
@@ -104,16 +104,17 @@ class Interval(base.Interval):
 
     def get(
         self, alpha: float = 0.05, atol: float = 1e-9
-    ) -> List[List[Optional[float]]]:
+    ) -> List[Tuple[Optional[float], Optional[float]]]:
         result = []
         n0 = float(self._impl[0].n) if any(self._impl) else 0
         if n0 > 0:
             for impl in self._impl:
+                left, right = impl.get(alpha, atol)
                 result.append(
-                    [
-                        v * float(impl.n) / n0 if v is not None else None
-                        for v in impl.get(alpha, atol)
-                    ]
+                    (
+                        left * float(impl.n) / n0 if left is not None else None,
+                        right * float(impl.n) / n0 if right is not None else None,
+                    )
                 )
         return result
 

--- a/src/estimators/math.py
+++ b/src/estimators/math.py
@@ -1,5 +1,5 @@
 from scipy.stats import beta  # type: ignore
-from typing import List
+from typing import List, Tuple
 
 
 class IncrementalFsum:
@@ -34,11 +34,13 @@ class IncrementalFsum:
         return sum(self.partials, 0.0)
 
 
-def clopper_pearson(successes: float, n: float, alpha: float = 0.05) -> List[float]:
+def clopper_pearson(
+    successes: float, n: float, alpha: float = 0.05
+) -> Tuple[float, float]:
     lower_bound = (
         beta.ppf(alpha / 2, successes, n - successes + 1) if successes > 0 else 0
     )
     upper_bound = (
         beta.ppf(1 - alpha / 2, successes + 1, n - successes) if successes < n else 1
     )
-    return [lower_bound, upper_bound]
+    return (lower_bound, upper_bound)

--- a/src/estimators/slates/base.py
+++ b/src/estimators/slates/base.py
@@ -1,7 +1,7 @@
 """ Interface for implementation of slates estimator """
 
 from abc import ABC, abstractmethod
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 
 class Estimator(ABC):
@@ -44,7 +44,7 @@ class Interval(ABC):
         ...
 
     @abstractmethod
-    def get(self, alpha: float) -> List[Optional[float]]:
+    def get(self, alpha: float) -> Tuple[Optional[float], Optional[float]]:
         """Calculates the CI
         Args:
                 alpha: alpha value

--- a/src/estimators/slates/gaussian.py
+++ b/src/estimators/slates/gaussian.py
@@ -1,7 +1,7 @@
 import math
 from estimators.slates import base
 from scipy import stats  # type: ignore
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 
 class Interval(base.Interval):
@@ -39,9 +39,9 @@ class Interval(base.Interval):
         self.weighted_reward += r * w * count
         self.weighted_reward_sq += ((r * w) ** 2) * count
 
-    def get(self, alpha: float = 0.05) -> List[Optional[float]]:
+    def get(self, alpha: float = 0.05) -> Tuple[Optional[float], Optional[float]]:
         if self.examples_count <= 1:
-            return [None, None]
+            return (None, None)
 
         z_gaussian_cdf = stats.norm.ppf(1 - alpha / 2)
         variance = (
@@ -50,7 +50,7 @@ class Interval(base.Interval):
         ) / (self.examples_count - 1)
         gauss_delta = z_gaussian_cdf * math.sqrt(variance / self.examples_count)
         ips = self.weighted_reward / self.examples_count
-        return [ips - gauss_delta, ips + gauss_delta]
+        return (ips - gauss_delta, ips + gauss_delta)
 
     def __add__(self, other: "Interval") -> "Interval":
         result = Interval()

--- a/tests/test_bandits.py
+++ b/tests/test_bandits.py
@@ -12,6 +12,7 @@ from utils import Helper, Scenario, get_intervals
 
 import pytest
 
+
 def assert_estimation_is_close(estimator, simulator, value):
     scenario = Scenario(simulator, estimator())
     scenario.get_estimate()

--- a/tests/test_ccb.py
+++ b/tests/test_ccb.py
@@ -6,8 +6,9 @@ from utils import Scenario, get_intervals
 
 import pytest
 
+
 def assert_is_within(value, interval):
-    if isinstance(value, list):
+    if isinstance(value, tuple):
         assert len(value) == 2
         assert value[0] >= interval[0]
         assert value[1] <= interval[1]

--- a/tests/test_multislot.py
+++ b/tests/test_multislot.py
@@ -5,7 +5,7 @@ from utils import Scenario, get_r_intervals, get_r_overall_intervals
 
 
 def assert_is_within(value, interval):
-    if isinstance(value, list):
+    if isinstance(value, tuple):
         assert len(value) == 2
         assert value[0] >= interval[0]
         assert value[1] <= interval[1]

--- a/tests/test_slates.py
+++ b/tests/test_slates.py
@@ -79,7 +79,7 @@ def test_higher_alpha_tighter_intervals():
 
 
 def test_no_data_estimation_is_none():
-    assert gaussian.Interval().get() == [None, None]
+    assert gaussian.Interval().get() == (None, None)
     assert pseudo_inverse.Estimator().get() is None
 
 

--- a/tests/test_slates.py
+++ b/tests/test_slates.py
@@ -6,6 +6,7 @@ from utils import Scenario, get_intervals
 
 import pytest
 
+
 def assert_estimation_is_close(estimator, simulator, value):
     scenario = Scenario(simulator, estimator())
     scenario.get_estimate()


### PR DESCRIPTION
Rationale of change is that lists have unbounded length, whereas we know the size of the sequence we are returning. Therefore, an explicitly typed tuple is easier to reason about.